### PR TITLE
Fix suboptimal allocation of BloomFilter bit array size

### DIFF
--- a/pybloom/benchmarks.py
+++ b/pybloom/benchmarks.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+#
+"""Test performance of BloomFilter at a set capacity and error rate."""
+import sys
+from pybloom import BloomFilter
+import bitarray, math, time
+
+def main():
+	request_error_rate = 0.01
+	f = BloomFilter(capacity=200000, error_rate=request_error_rate)
+	start = time.time()
+	for i in xrange(0, f.capacity):
+		f.add(i, skip_check=True)
+	end = time.time()
+	print "{:5.3f} seconds to add to capacity, {:10.2f} entries/second".format( end-start, f.capacity/(end-start))
+	oneBits = f.bitarray.count(True)
+	zeroBits = f.bitarray.count(False)
+	#print "Number of 1 bits:", oneBits
+	#print "Number of 0 bits:", zeroBits
+	print "Number of Filter Bits:", f.num_bits
+	print "Number of slices:", f.num_slices
+	print "Bits per slice:", f.bits_per_slice
+	print "------"
+	print "Fraction of 1 bits at capacity: {:5.3f}".format( oneBits / float(f.num_bits) )
+	# Look for false positives and measure the actual fp rate
+	trials = f.capacity
+	fp = 0
+	start = time.time()
+	for i in xrange(f.capacity, f.capacity+trials):
+		if i in f:
+			fp += 1
+	end = time.time()
+	print "{:5.3f} seconds to check false positives, {:10.2f} checks/second".format(end-start, trials/(end-start))
+	print "Requested FP rate: {:2.4f}".format( request_error_rate )
+	print "Experimental false positive rate: {:2.4f}".format( fp / float(trials))
+	# Compute theoretical fp max (Goel/Gupta)
+	k = f.num_slices
+	m = f.num_bits
+	n = f.capacity
+	fp_theory = math.pow((1 - math.exp(-k * (n+0.5)/(m-1))), k)
+	print "Projected FP rate (Goel/Gupta): {:2.6f}".format( fp_theory )
+
+if __name__ == '__main__' : 
+	status = main()
+	sys.exit(status)

--- a/pybloom/pybloom.py
+++ b/pybloom/pybloom.py
@@ -117,10 +117,8 @@ class BloomFilter(object):
         # n ~= (k * m) * ((ln(2) ** 2) / abs(ln(P)))
         # m ~= n * abs(ln(P)) / (k * (ln(2) ** 2))
         num_slices = int(math.ceil(math.log(1 / error_rate, 2)))
-        # the error_rate constraint assumes a fill rate of 1/2
-        # so we double the capacity to simplify the API
         bits_per_slice = int(math.ceil(
-            (2 * capacity * abs(math.log(error_rate))) /
+            (capacity * abs(math.log(error_rate))) /
             (num_slices * (math.log(2) ** 2))))
         self._setup(error_rate, num_slices, bits_per_slice, capacity, 0)
         self.bitarray = bitarray.bitarray(self.num_bits, endian='little')


### PR DESCRIPTION
Empirical measurement of the false positive rate of BloomFilter is
substantially lower that the requested error rates. For example, a
BloomFilter with capacity 20,000 and an error rate of .01, gives actual
error rate .0003. This is because the bit size allocated to the filter
is unnecessarily large, and does not match the theoretically calculated
required size.
