### PR TITLE
Add ability to write to StringIO and cStringIO objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info
 build
 dist
+.venv

--- a/pybloom/pybloom.py
+++ b/pybloom/pybloom.py
@@ -47,7 +47,9 @@ except ImportError:
 __version__ = '2.0'
 __author__  = "Jay Baird <jay.baird@me.com>, Bob Ippolito <bob@redivi.com>,\
                Marius Eriksen <marius@monkey.org>,\
-               Alex Brasetvik <alex@brasetvik.com>"
+               Alex Brasetvik <alex@brasetvik.com>,\
+               Matt Bachmann <bachmann.matt@gmail.com>,\
+              "
 
 def make_hashfuncs(num_slices, num_bits):
     if num_bits >= (1 << 31):

--- a/pybloom/pybloom.py
+++ b/pybloom/pybloom.py
@@ -36,6 +36,8 @@ Requires the bitarray library: http://pypi.python.org/pypi/bitarray/
 import math
 import hashlib
 from struct import unpack, pack, calcsize
+import StringIO
+import cStringIO
 
 try:
     import bitarray
@@ -227,7 +229,10 @@ have equal capacity and error rate")
         efficient than pickling the object."""
         f.write(pack(self.FILE_FMT, self.error_rate, self.num_slices,
                      self.bits_per_slice, self.capacity, self.count))
-        self.bitarray.tofile(f)
+        (f.write(self.bitarray.tobytes()) if isinstance(f, (StringIO.StringIO,
+                                                            cStringIO.InputType,
+                                                            cStringIO.OutputType))
+         else self.bitarray.tofile(f))
 
     @classmethod
     def fromfile(cls, f, n=-1):
@@ -242,9 +247,16 @@ have equal capacity and error rate")
         filter._setup(*unpack(cls.FILE_FMT, f.read(headerlen)))
         filter.bitarray = bitarray.bitarray(endian='little')
         if n > 0:
-            filter.bitarray.fromfile(f, n - headerlen)
+            (filter.bitarray.frombytes(f.read(n-headerlen))
+             if isinstance(f, (StringIO.StringIO,
+                               cStringIO.InputType,
+                               cStringIO.OutputType))
+             else filter.bitarray.fromfile(f, n - headerlen))
         else:
-            filter.bitarray.fromfile(f)
+            (filter.bitarray.frombytes(f.read()) if isinstance(f, (StringIO.StringIO,
+                                                                   cStringIO.InputType,
+                                                                   cStringIO.OutputType))
+             else filter.bitarray.fromfile(f))
         if filter.num_bits != filter.bitarray.length() and \
                (filter.num_bits + (8 - filter.num_bits % 8)
                 != filter.bitarray.length()):

--- a/pybloom/tests.py
+++ b/pybloom/tests.py
@@ -1,3 +1,5 @@
+import StringIO
+import cStringIO
 import os
 import doctest
 import unittest
@@ -80,17 +82,23 @@ class Serialization(unittest.TestCase):
             for item in self.EXPECTED:
                 filter.add(item)
 
-            # It seems bitarray is finicky about the object being an
-            # actual file, so we can't just use StringIO. Grr.
             f = tempfile.TemporaryFile()
             filter.tofile(f)
+
+            stringio = StringIO.StringIO()
+            cstringio = cStringIO.StringIO()
+            filter.tofile(stringio)
+            filter.tofile(cstringio)
             del filter
 
             f.seek(0)
-            filter = klass.fromfile(f)
-
-            for item in self.EXPECTED:
-                self.assert_(item in filter)
+            stringio.seek(0)
+            cstringio.seek(0)
+            for filter in (klass.fromfile(f),
+                           klass.fromfile(stringio),
+                           klass.fromfile(cstringio)):
+                for item in self.EXPECTED:
+                    self.assert_(item in filter)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I wanted the ability to write to strings and it seems like this was the easiest way. I considered separate frombytes and tobytes functions/methods but generally this seemed like the easier solution with the least duplication
