### PR TITLE
setup.py change for pip-interoperability

### DIFF
--- a/pybloom/__init__.py
+++ b/pybloom/__init__.py
@@ -1,3 +1,6 @@
 """pybloom
 
 """
+
+from .pybloom import BloomFilter, ScalableBloomFilter
+

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ setup(
     platforms=['any'],
     test_suite="pybloom.tests",
     zip_safe=True,
-    install_requires=['bitarray>=0.3.4']
+    install_requires=['bitarray>=0.3.4'],
+    packages=['pybloom']
 )


### PR DESCRIPTION
I could not install python-bloomfilter using

```
pip install git+ssh://git@github.com/jaybaird/python-bloomfilter.git#egg=python_bloomfilter
```

That is, the install succeeds, but I could not import pybloom or its parts afterwards.

I changed setup.py and **init**.py so that setup.py install results are in line with examples given in the readme.
