### PR TITLE
return bit indices set during an add

### DIFF
--- a/pybloom/pybloom.py
+++ b/pybloom/pybloom.py
@@ -206,6 +206,23 @@ class BloomFilter(object):
         else:
             return True
 
+    def add_return_bits(self, key):
+        """ Adds a key to this bloom filter and return a list of bit indices set."""
+        bits_per_slice = self.bits_per_slice
+        hashes = self.make_hashes(key)
+        if self.count > self.capacity:
+            raise IndexError("BloomFilter is at capacity")
+
+        offset = 0
+        indices = []
+
+        for k in hashes:
+            self.bitarray[offset + k] = True
+            indices.append(offset + k)
+            offset += bits_per_slice
+
+        return indices
+
     def copy(self):
         """Return a copy of this bloom filter.
         """


### PR DESCRIPTION
My project involves multiple nodes maintaining and syncing up bloom filters. To do this efficiently, I need to know which indices get set during an add operation. This PR adds a method to do that.

This isn't quite ready to be merged. Here are some questions for you:
- would it slow things down to consume the hashes iterator before the loop so we can pre-allocate the indices list? I'd like to avoid dynamically expanding the indices list. 
- what do you want the client interface for this to be? My first thought was that add_return_bits is a more general interface and that `add` should be calling it, but that would introduce a memory/gc perf regression for code not using the bit indices.
