### PR TITLE
assign hashfn_name to BloomFilter object

### DIFF
--- a/pybloom/pybloom.py
+++ b/pybloom/pybloom.py
@@ -69,6 +69,8 @@ def make_hashfuncs(num_slices, num_bits):
         hashfn = hashlib.sha1
     else:
         hashfn = hashlib.md5
+    hashfn_name = hashfn.__name__
+
     fmt = fmt_code * (hashfn().digest_size // chunk_size)
     num_salts, extra = divmod(num_slices, len(fmt))
     if extra:
@@ -95,7 +97,7 @@ def make_hashfuncs(num_slices, num_bits):
                 if i >= num_slices:
                     return
 
-    return _make_hashfuncs
+    return _make_hashfuncs, hashfn_name
 
 
 class BloomFilter(object):
@@ -145,7 +147,7 @@ class BloomFilter(object):
         self.capacity = capacity
         self.num_bits = num_slices * bits_per_slice
         self.count = count
-        self.make_hashes = make_hashfuncs(self.num_slices, self.bits_per_slice)
+        self.make_hashes, self.hashfn_name = make_hashfuncs(self.num_slices, self.bits_per_slice)
 
     def __contains__(self, key):
         """Tests a key's membership in this bloom filter.
@@ -282,7 +284,7 @@ have equal capacity and error rate")
 
     def __setstate__(self, d):
         self.__dict__.update(d)
-        self.make_hashes = make_hashfuncs(self.num_slices, self.bits_per_slice)
+        self.make_hashes, self.hashfn_name = make_hashfuncs(self.num_slices, self.bits_per_slice)
 
 class ScalableBloomFilter(object):
     SMALL_SET_GROWTH = 2 # slower, but takes up less memory

--- a/pybloom/pybloom.py
+++ b/pybloom/pybloom.py
@@ -52,6 +52,24 @@ __author__  = "Jay Baird <jay.baird@me.com>, Bob Ippolito <bob@redivi.com>,\
               "
 
 def make_hashfuncs(num_slices, num_bits):
+    """
+    >>> from pybloom.pybloom import make_hashfuncs
+    >>> make_hashes, hashfn = make_hashfuncs(100, 20)
+    >>> hashfn
+    <built-in function openssl_sha512>
+    >>> make_hashes, hashfn = make_hashfuncs(20, 3)
+    >>> hashfn
+    <built-in function openssl_sha384>
+    >>> make_hashes, hashfn =  make_hashfuncs(15, 2)
+    >>> hashfn
+    <built-in function openssl_sha256>
+    >>> make_hashes, hashfn = make_hashfuncs(10, 2)
+    >>> hashfn
+    <built-in function openssl_sha1>
+    >>> make_hashes, hashfn = make_hashfuncs(5, 1)
+    >>> hashfn
+    <built-in function openssl_md5>
+    """
     if num_bits >= (1 << 31):
         fmt_code, chunk_size = 'Q', 8
     elif num_bits >= (1 << 15):
@@ -75,7 +93,7 @@ def make_hashfuncs(num_slices, num_bits):
     if extra:
         num_salts += 1
     salts = tuple(hashfn(hashfn(pack('I', i)).digest()) for i in range_fn(num_salts))
-    def _make_hashfuncs(key):
+    def _hash_maker(key):
         if running_python_3:
             if isinstance(key, str):
                 key = key.encode('utf-8')
@@ -96,7 +114,7 @@ def make_hashfuncs(num_slices, num_bits):
                 if i >= num_slices:
                     return
 
-    return _make_hashfuncs, hashfn
+    return _hash_maker, hashfn
 
 
 class BloomFilter(object):

--- a/pybloom/pybloom.py
+++ b/pybloom/pybloom.py
@@ -69,7 +69,6 @@ def make_hashfuncs(num_slices, num_bits):
         hashfn = hashlib.sha1
     else:
         hashfn = hashlib.md5
-    hashfn_name = hashfn.__name__
 
     fmt = fmt_code * (hashfn().digest_size // chunk_size)
     num_salts, extra = divmod(num_slices, len(fmt))
@@ -97,7 +96,7 @@ def make_hashfuncs(num_slices, num_bits):
                 if i >= num_slices:
                     return
 
-    return _make_hashfuncs, hashfn_name
+    return _make_hashfuncs, hashfn
 
 
 class BloomFilter(object):
@@ -147,7 +146,7 @@ class BloomFilter(object):
         self.capacity = capacity
         self.num_bits = num_slices * bits_per_slice
         self.count = count
-        self.make_hashes, self.hashfn_name = make_hashfuncs(self.num_slices, self.bits_per_slice)
+        self.make_hashes, self.hashfn = make_hashfuncs(self.num_slices, self.bits_per_slice)
 
     def __contains__(self, key):
         """Tests a key's membership in this bloom filter.
@@ -284,7 +283,7 @@ have equal capacity and error rate")
 
     def __setstate__(self, d):
         self.__dict__.update(d)
-        self.make_hashes, self.hashfn_name = make_hashfuncs(self.num_slices, self.bits_per_slice)
+        self.make_hashes, self.hashfn = make_hashfuncs(self.num_slices, self.bits_per_slice)
 
 class ScalableBloomFilter(object):
     SMALL_SET_GROWTH = 2 # slower, but takes up less memory

--- a/pybloom/test_pybloom.py
+++ b/pybloom/test_pybloom.py
@@ -7,20 +7,10 @@ try:
     import cStringIO
 except ImportError:
     from io import BytesIO as StringIO
-import os
-import doctest
 import unittest
 import random
 import tempfile
-from unittest import TestSuite
 
-def additional_tests():
-    proj_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    readme_fn = os.path.join(proj_dir, 'README.txt')
-    suite = TestSuite([doctest.DocTestSuite('pybloom.pybloom')])
-    if os.path.exists(readme_fn):
-        suite.addTest(doctest.DocFileSuite(readme_fn, module_relative=False))
-    return suite
 
 class TestUnionIntersection(unittest.TestCase):
     def test_union(self):

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,4 @@
 envlist = py26,py27,py34
 [testenv]
 deps=pytest
-commands=py.test pybloom/tests.py
+commands=py.test --doctest-modules


### PR DESCRIPTION
We are using `pybloom.BloomFilter` to construct a multi-layer filter cascade which we will then write to a file. We need to include each layer's hash function in the file.

This code introduces a `hashfn_name` property to `BloomFilter`, and assigns the selected `hashfn.__name__` to it.