### PR TITLE
docs: fix simple typo, implmentation -> implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ pybloom
     :target: https://travis-ci.org/jaybaird/python-bloomfilter
 
 ``pybloom`` is a module that includes a Bloom Filter data structure along with
-an implmentation of Scalable Bloom Filters as discussed in:
+an implementation of Scalable Bloom Filters as discussed in:
 
 P. Almeida, C.Baquero, N. Preguiça, D. Hutchison, Scalable Bloom Filters,
 (GLOBECOM 2007), IEEE, 2007.


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `implementation` rather than `implmentation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md