### PR TITLE
dependency fix: bitarray v1.5.1

### DIFF
--- a/pybloom/pybloom.py
+++ b/pybloom/pybloom.py
@@ -268,9 +268,9 @@ have equal capacity and error rate")
         else:
             (filter.bitarray.frombytes(f.read()) if is_string_io(f)
              else filter.bitarray.fromfile(f))
-        if filter.num_bits != filter.bitarray.length() and \
-               (filter.num_bits + (8 - filter.num_bits % 8)
-                != filter.bitarray.length()):
+        if filter.num_bits != len(filter.bitarray) and \
+            (filter.num_bits + (8 - filter.num_bits % 8)
+                != len(filter.bitarray)):
             raise ValueError('Bit length mismatch!')
 
         return filter

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     platforms=['any'],
     test_suite="pybloom.tests",
     zip_safe=True,
-    install_requires=['bitarray>=0.3.4'],
+    install_requires=['bitarray>1.5.1'],
     packages=['pybloom']
 )


### PR DESCRIPTION
Due to the update of bitarray(refer [HERE](https://github.com/ilanschnell/bitarray/blob/master/CHANGE_LOG))
> 2021-04-14   2.0.0:
> * remove `.length()` method (deprecated since 1.5.1 - use `len()`)

the codes in `fromfile` method update with `len()` instead of `.length()`.

Code tested after the update.
